### PR TITLE
Remove `pause` from IV plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -----------------------------------------------------------------------------------------------
+## v1.2.5
 
+### Changed
+  - removed `pause` call in `plot_IV`
 
 ## v1.2.4
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChargeTransport"
 uuid = "25c3eafe-d88c-11e9-3031-f396758f002a"
-version = "1.2.4"
+version = "1.2.5"
 authors = ["Dilara Abdel <dilara.abdel@wias-berlin.de>, Patricio Farrell <patricio.farrell@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
 
 [deps]

--- a/src/ct_plotting.jl
+++ b/src/ct_plotting.jl
@@ -529,7 +529,6 @@ function plot_IV(Plotter, biasValues, IV, title, ; plotGridpoints = false)
     Plotter.xlabel("bias [V]")
     Plotter.ylabel("total current [A]")
     Plotter.tight_layout()
-    Plotter.pause(1.0e-5)
 
     return nothing
 end


### PR DESCRIPTION
I think this is not needed.

But it will open an external window if used in `Pluto` .. hence, let us remove it.