### PR TITLE
docs: remove space in links

### DIFF
--- a/docs/src/backgroundinfo.md
+++ b/docs/src/backgroundinfo.md
@@ -79,7 +79,7 @@ For a comprehensive overview of drift-diffusion models, semiconductor applicatio
 3. S. M. Sze and K. K. Ng. [Physics of Semiconductor Devices](https://onlinelibrary.wiley.com/doi/book/10.1002/0470068329). Wiley, 2006.
 
 
-# [Notation] (@id notation)
+# [Notation](@id notation)
 
 | **symbol** | **physical quantity** |   |   |   |   | **symbol** | **physical quantity** |
 | :---:         |     :---:      |          :---: |          :---: |          :---: |          :---: |          :---: |          :---: |


### PR DESCRIPTION
This should fix the docs: see Julia 1.12.2 related change: https://github.com/JuliaLang/julia/commit/2e88e34e88cafe546671bd61cb4336330447225f