### PR TITLE
ci: macos-14-large for intel cpu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-14 # intel
+          - macOS-14-large # intel
           - macOS-15 # arm
         arch:
           - x64
@@ -31,7 +31,7 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: aarch64
-          - os: macOS-14 
+          - os: macOS-14-large
             arch: aarch64
           - os: macOS-15
             arch: x64


### PR DESCRIPTION
macos-14 supports arm only