### PR TITLE
ci: no more x64 macos runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-14 # intel
-          - macOS-15 # arm
+          - macOS-14
+          - macOS-15
         arch:
           - x64
           - aarch64
@@ -32,7 +32,7 @@ jobs:
           - os: windows-latest
             arch: aarch64
           - os: macOS-14 
-            arch: aarch64
+            arch: x64
           - os: macOS-15
             arch: x64
     steps:


### PR DESCRIPTION
macos-13 was the last runner to support x64 and this is now deprecated. The macos-14-x64 runs were already redirected to arm runs