### PR TITLE
Fix bug in vacancy energy calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -----------------------------------------------------------------------------------------------
 
-## v1.7.0
+## v1.7.1
 
 ### Fixed
 - internal vacancy energy calculation now works for charge numbers beyond one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -----------------------------------------------------------------------------------------------
+
+## v1.7.0
+
+### Fixed
+- internal vacancy energy calculation now works for charge numbers beyond one
+
+
 ## v1.7.0
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChargeTransport"
 uuid = "25c3eafe-d88c-11e9-3031-f396758f002a"
-version = "1.7.0"
+version = "1.7.1"
 authors = ["Dilara Abdel <dilara.abdel@wias-berlin.de>, Patricio Farrell <patricio.farrell@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>", "Marieke Osewold <marieke.osewold@wias-berlin.de>"]
 
 [deps]

--- a/src/ct_system.jl
+++ b/src/ct_system.jl
@@ -1393,7 +1393,7 @@ function build_system(grid, data, ::Type{ContQF}; kwargs...)
                 za = data.params.chargeNumbers[icc]
                 Ca = data.params.doping[icc, ireg]
 
-                Ea = trunc((k_B * T * log((Ca / Na) / (1 - Ca / Na)) + za * q * (psi1 + psi2) / 2) / q, digits = 3) * q
+                Ea = trunc((k_B * T / za * log((Ca / Na) / (1 - Ca / Na)) + q * (psi1 + psi2) / 2) / q, digits = 3) * q
 
                 data.params.bandEdgeEnergy[icc, ireg] = Ea
 
@@ -1966,7 +1966,7 @@ function _equilibrium_solve!(::Val{true}, ctsys::System; inival, control, nonlin
             za = params.chargeNumbers[icc]
 
             # E0, E1 in eV
-            E0 = k_B * T * log((Ca / Na) / (1 - Ca / Na)) + za * q * 0.5 * (psiL + psiR) # in eV
+            E0 = k_B * T / za * log((Ca / Na) / (1 - Ca / Na)) + q * 0.5 * (psiL + psiR) # in eV
             E0 = round(E0 / q, digits = 3) * q
 
             # --- Find one correct pair E0, y0 ---


### PR DESCRIPTION
In PR #78, there was a minor bug. The initial guess for the vacancy energy was incorrect for charge numbers $z_\alpha \neq 1$.
We make use of

$$
n_\alpha = N_\alpha \mathcal{F}_\alpha ( z_\alpha \frac{q(\varphi_\alpha - \psi)  + E_\alpha }{k_B T} ).
$$

In equilibrium, we set $\varphi_\alpha = 0$. Reformulating for $E_\alpha$ gives

$$
E_\alpha =   \frac{k_B T}{z_\alpha} \mathcal{F}_\alpha^{-1} (\frac{n_\alpha}{N_\alpha}) + q \psi.
$$

This bug is now fixed.