### PR TITLE
fix image path

### DIFF
--- a/docs/src/backgroundinfo.md
+++ b/docs/src/backgroundinfo.md
@@ -83,9 +83,7 @@ for all $\mathbf{x} \in \Gamma_\text{G}$ and $t \in [0,T]$. Here, $\varepsilon_\
 
 For the derivation of the Robin boundary condition, we consider the gate contact region in more detail (see Figure). We distinguish two separate domains: the semiconductor domain $\Omega_\text{s}$ and the oxide layer $\Omega_\text{ox}$ characterizing the gate contact.
 
-<p align="center">
-  <img src="images/Gate-boundary-condition.png" width="300"/>
-</p>
+![GateBoundary](images/Gate-boundary-condition.png)
 
 In the subdomains we have
 ```math


### PR DESCRIPTION
I fixed the broken image path for the gate boundary condition image within the gate boundary documentation.

My Steps:
- Removed messy/broken HTML tag `<p>`, which was printed as raw text by Documenter.jl
- Switched to native markdown syntax (`![GateBoundary](images/Gate-boundary-condition.png)`) which allows Documenter.jl to correctly resolve the path

@pjaap That was the simplest fix. Is that fine, or should we find a way to make the HTML approach work?

FYI: @PatricioFarrell 