### PR TITLE
Allow for user defined reaction function

### DIFF
--- a/src/ct_physics.jl
+++ b/src/ct_physics.jl
@@ -716,8 +716,11 @@ Master reaction! function. This is the function which enters VoronoiFVM and hand
 reaction terms for concrete calculation type and bulk recombination model.
 
 """
-reaction!(f, u, node, data) = reaction!(f, u, node, data, data.calculationType)
-
+function reaction!(f, u, node, data)
+    reaction!(f, u, node, data, data.calculationType)
+    data.customReaction(f,u,node,data)
+    nothing
+end
 """
 $(TYPEDSIGNATURES)
 Reaction in case of equilibrium, i.e. no generation and recombination is considered.

--- a/src/ct_physics.jl
+++ b/src/ct_physics.jl
@@ -718,8 +718,8 @@ reaction terms for concrete calculation type and bulk recombination model.
 """
 function reaction!(f, u, node, data)
     reaction!(f, u, node, data, data.calculationType)
-    data.customReaction(f,u,node,data)
-    nothing
+    data.customReaction(f, u, node, data)
+    return nothing
 end
 """
 $(TYPEDSIGNATURES)

--- a/src/ct_system.jl
+++ b/src/ct_system.jl
@@ -946,7 +946,12 @@ but also all physical parameters for a drift-diffusion simulation of a semicondu
 $(TYPEDFIELDS)
 
 """
-mutable struct Data{TFuncs <: Function, TVoltageFunc <: Function, TGenerationData <: Union{Array{Float64, 1}, Array{Float64, 2}, Array{Float64, 3}, Function}}
+mutable struct Data{
+        TFuncs <: Function,
+        TVoltageFunc <: Function,
+        TGenerationData <: Union{Array{Float64, 1}, Array{Float64, 2}, Array{Float64, 3}, Function},
+        TParamsUser, TCustomReaction,
+    }
 
     ###############################################################
     ####                   model information                   ####
@@ -1148,8 +1153,18 @@ mutable struct Data{TFuncs <: Function, TVoltageFunc <: Function, TGenerationDat
     """
     constants::Constants
 
+    """
+    A struct for user defined parameters. `nothing` by default.    
+    """
+    paramsuser::TParamsUser
+
+    """
+        Custom user defined reaction. Empty by default.
+    """
+    customReaction::TCustomReaction
+
     ###############################################################
-    Data{TFuncs, TVoltageFunc, TGenerationData}() where {TFuncs, TVoltageFunc, TGenerationData} = new()
+    Data{TFuncs, TVoltageFunc, TGenerationData, TParamsUser, TCustomReaction}() where {TFuncs, TVoltageFunc, TGenerationData, TParamsUser, TCustomReaction} = new()
 
 end
 
@@ -1163,7 +1178,16 @@ including the physical parameters, but also some numerical information
 are located.
 
 """
-function Data(grid, numberOfCarriers; constants = ChargeTransport.constants, contactVoltageFunction = [zeroVoltage for i in 1:grid[NumBFaceRegions]], generationData = [0.0], statfunctions::Type{TFuncs} = StandardFuncSet, numberOfEigenvalues = 0) where {TFuncs}
+function Data(
+        grid, numberOfCarriers;
+        constants = ChargeTransport.constants,
+        contactVoltageFunction = [zeroVoltage for i in 1:grid[NumBFaceRegions]],
+        generationData = [0.0],
+        statfunctions::Type{TFuncs} = StandardFuncSet,
+        paramsuser = nothing,
+        customReaction = (y, u, node, data) -> nothing,
+        numberOfEigenvalues = 0
+    ) where {TFuncs}
 
     numberOfBoundaryRegions = grid[NumBFaceRegions]
     numberOfRegions = grid[NumCellRegions]
@@ -1180,7 +1204,7 @@ function Data(grid, numberOfCarriers; constants = ChargeTransport.constants, con
     TypeGenerationData = typeof(generationData)
 
     # construct a data struct
-    data = Data{TFuncs, TypeVoltageFunc, TypeGenerationData}()
+    data = Data{TFuncs, TypeVoltageFunc, TypeGenerationData, typeof(paramsuser), typeof(customReaction)}()
 
     ###############################################################
     ####                   model information                   ####
@@ -1257,7 +1281,8 @@ function Data(grid, numberOfCarriers; constants = ChargeTransport.constants, con
     data.params = Params(grid[NumCellRegions], numberOfBoundaryRegions, numberOfCarriers)
     data.paramsnodal = ParamsNodal(grid, numberOfCarriers)
     data.paramsoptical = ParamsOptical(grid, numberOfCarriers, numberOfEigenvalues)
-
+    data.paramsuser = paramsuser
+    data.customReaction = customReaction
     ###############################################################
 
     data.constants = constants


### PR DESCRIPTION
This commit adds `paramsuser` and `customReaction` to the Data struct. By default they are trivial (`nothing` resp. function doing nothing).

The drawback is an additional call in each reaction.